### PR TITLE
The header used Chinese in the English version

### DIFF
--- a/docs/v4/tools.md
+++ b/docs/v4/tools.md
@@ -557,7 +557,8 @@
 @zh *预先命名你的音轨将使创建过程更加顺利，并有助于识别你的音轨以供将来使用。*
 :::
 
-::: important
+@en ::: important
+@zh ::: important 重要通知
 @en **The MIDI being created can support the following:**
 @zh **要创建的MIDI可支持以下条目：**
 

--- a/docs/v4/tools.md
+++ b/docs/v4/tools.md
@@ -557,7 +557,7 @@
 @zh *预先命名你的音轨将使创建过程更加顺利，并有助于识别你的音轨以供将来使用。*
 :::
 
-::: important 重要通知
+::: important
 @en **The MIDI being created can support the following:**
 @zh **要创建的MIDI可支持以下条目：**
 


### PR DESCRIPTION
The section header used Chinese in the English version. Since all the other headers used English without a Chinese version following next to it, I assumed this was a small bug.